### PR TITLE
Watcher Wing Trophy Effect increase

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -230,7 +230,7 @@
 	desc = "A wing ripped from a watcher. Suitable as a trophy for a kinetic crusher."
 	icon_state = "watcher_wing"
 	denied_type = /obj/item/crusher_trophy/watcher_wing
-	bonus_value = 5
+	bonus_value = 10
 
 /obj/item/crusher_trophy/watcher_wing/effect_desc()
 	return "mark detonation to prevent certain creatures from using certain attacks for <b>[bonus_value*0.1]</b> second\s"


### PR DESCRIPTION
:cl: 
tweak: increased the watcher trophy effect for the kinetic crusher last 1 second instead of 0.5 seconds. 
/:cl:

[why]: well it doesn't really do anything atm. It's basically useless.
